### PR TITLE
fix: Windows subprocess encoding error, env var passthrough, and cluster reuse content bug

### DIFF
--- a/src/sirchmunk/api/chat.py
+++ b/src/sirchmunk/api/chat.py
@@ -300,13 +300,26 @@ def get_search_instance(log_callback=None):
             log_callback=log_callback,
         )
         
-        # Create and return AgenticSearch instance with configured LLM
-        return AgenticSearch(llm=llm, log_callback=log_callback)
-    
+        # Read cluster reuse settings from environment
+        enable_cluster_reuse = os.getenv("SIRCHMUNK_ENABLE_CLUSTER_REUSE", "true").lower() == "true"
+        cluster_sim_threshold = float(os.getenv("CLUSTER_SIM_THRESHOLD", "0.85"))
+        cluster_sim_top_k = int(os.getenv("CLUSTER_SIM_TOP_K", "3"))
+
+        return AgenticSearch(
+            llm=llm,
+            log_callback=log_callback,
+            reuse_knowledge=enable_cluster_reuse,
+            cluster_sim_threshold=cluster_sim_threshold,
+            cluster_sim_top_k=cluster_sim_top_k,
+        )
+
     except Exception as e:
-        # If settings retrieval fails, fall back to default AgenticSearch initialization
         print(f"[WARNING] Please config ENVs: LLM_BASE_URL, LLM_API_KEY, LLM_MODEL_NAME. Error: {e}")
-        return AgenticSearch(log_callback=log_callback)
+        enable_cluster_reuse = os.getenv("SIRCHMUNK_ENABLE_CLUSTER_REUSE", "true").lower() == "true"
+        return AgenticSearch(
+            log_callback=log_callback,
+            reuse_knowledge=enable_cluster_reuse,
+        )
 
 
 _COOLDOWN_SECONDS = 1.0

--- a/src/sirchmunk/api/search.py
+++ b/src/sirchmunk/api/search.py
@@ -119,10 +119,17 @@ def _get_search_instance() -> AgenticSearch:
         model=model_name,
     )
 
+    enable_cluster_reuse = os.getenv("SIRCHMUNK_ENABLE_CLUSTER_REUSE", "true").lower() == "true"
+    cluster_sim_threshold = float(os.getenv("CLUSTER_SIM_THRESHOLD", "0.85"))
+    cluster_sim_top_k = int(os.getenv("CLUSTER_SIM_TOP_K", "3"))
+
     _search_instance = AgenticSearch(
         llm=llm,
         work_path=DEFAULT_SIRCHMUNK_WORK_PATH,
         verbose=False,
+        reuse_knowledge=enable_cluster_reuse,
+        cluster_sim_threshold=cluster_sim_threshold,
+        cluster_sim_top_k=cluster_sim_top_k,
     )
     _search_config = current_config
 

--- a/src/sirchmunk/cli/web_launcher.py
+++ b/src/sirchmunk/cli/web_launcher.py
@@ -62,7 +62,12 @@ def get_node_version() -> Optional[str]:
     """Get the installed Node.js version string, or None."""
     try:
         result = subprocess.run(
-            ["node", "--version"], capture_output=True, text=True, timeout=10
+            ["node", "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
         )
         return result.stdout.strip() if result.returncode == 0 else None
     except Exception:
@@ -172,6 +177,8 @@ def build_frontend(
             cwd=str(web_dir),
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=300,
         )
         if result.returncode != 0:
@@ -202,6 +209,8 @@ def build_frontend(
             cwd=str(web_dir),
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             env=build_env,
             timeout=600,
         )

--- a/src/sirchmunk/search.py
+++ b/src/sirchmunk/search.py
@@ -260,7 +260,12 @@ class AgenticSearch(BaseSearch):
                 content = existing_cluster.content
                 if isinstance(content, list):
                     content = "\n".join(content)
-                return str(content) if content else "Knowledge cluster found but content is empty"
+                if not content:
+                    await self._logger.warning(
+                        f"Cluster {existing_cluster.id} has empty content, falling back to full search"
+                    )
+                    return None
+                return str(content)
         
         except Exception as e:
             await self._logger.warning(
@@ -864,6 +869,9 @@ class AgenticSearch(BaseSearch):
                     query_keywords=query_keywords,
                     top_k_files=top_k_files,
                 )
+            elif answer and not cluster.content:
+                cluster.content = answer
+                cluster.search_results.append(answer)
 
         # Sync LLM token accounting into context for accurate summary.
         # All parallel probes / builders append to self.llm_usages;


### PR DESCRIPTION
## Summary

This PR fixes three bugs discovered during testing on Windows:

### 1. `UnicodeDecodeError` on Windows during `sirchmunk web init`

**Problem:** On Windows with Chinese locale, `subprocess.run()` defaults to GBK encoding for reading subprocess output, but `npm` outputs UTF-8. This causes `UnicodeDecodeError: 'gbk' codec can't decode byte 0xb2` when running `npm install` or `npm run build`.

**Fix:** Added `encoding="utf-8"` and `errors="replace"` to `subprocess.run()` calls in `web_launcher.py` (`get_node_version`, `npm install`, `npm run build`).

**File:** `src/sirchmunk/cli/web_launcher.py`

### 2. `SIRCHMUNK_ENABLE_CLUSTER_REUSE` env var ignored by Web API

**Problem:** The MCP service correctly reads `SIRCHMUNK_ENABLE_CLUSTER_REUSE` from environment and passes it to `AgenticSearch`, but the Web API endpoints (`api/chat.py` and `api/search.py`) never read this env var. They always use the default value `True`, making it impossible to disable cluster reuse via environment variable when using the Web UI.

**Fix:** Both `api/chat.py::get_search_instance()` and `api/search.py::_get_search_instance()` now read `SIRCHMUNK_ENABLE_CLUSTER_REUSE`, `CLUSTER_SIM_THRESHOLD`, and `CLUSTER_SIM_TOP_K` from environment and pass them to `AgenticSearch`.

**Files:** `src/sirchmunk/api/chat.py`, `src/sirchmunk/api/search.py`

### 3. "Knowledge cluster found but content is empty" on cluster reuse

**Problem:** When `knowledge_base.build()` returns a cluster with evidence units but empty `content`, the code enters the ReAct refinement branch (Phase 4). The ReAct agent generates a valid answer, but since `cluster` already exists (not `None`), the answer is never stored back into `cluster.content`. The cluster gets persisted with `content=None`. On subsequent queries that match this cluster via semantic similarity, `_try_reuse_cluster()` returns the error string "Knowledge cluster found but content is empty" instead of actual content.

**Fix (two parts):**
1. **Prevention:** In the Phase 4 `else` branch, when `cluster` exists but `content` is empty, backfill `cluster.content` with the ReAct-generated answer before persistence.
2. **Graceful degradation:** In `_try_reuse_cluster()`, when a reused cluster has empty content, return `None` to fall back to a full search instead of returning an error string to the user.

**File:** `src/sirchmunk/search.py`

## Test Plan

- [x] Verified `sirchmunk web init` completes without `UnicodeDecodeError` on Windows (Chinese locale)
- [x] Verified `SIRCHMUNK_ENABLE_CLUSTER_REUSE=false` correctly disables cluster reuse in Web UI
- [x] Verified new clusters are saved with non-empty `content` field
- [x] Verified cluster reuse returns actual content instead of error message
- [x] Verified old clusters with empty content gracefully fall back to full search