### PR TITLE
fix: the parameter enable_thinking is unknown in standard OpenAI API …

### DIFF
--- a/src/sirchmunk/llm/openai_chat.py
+++ b/src/sirchmunk/llm/openai_chat.py
@@ -120,11 +120,11 @@ class OpenAIChat:
 
         if "openai.com" in url:
             return "openai"
-        if "anthropic.com" in url:
+        elif "anthropic.com" in url:
             return "anthropic"
-        if "generativelanguage.googleapis.com" in url or "googleapis.com" in url:
+        elif "googleapis.com" in url:
             return "gemini"
-        if "deepseek.com" in url:
+        elif "deepseek.com" in url:
             return "deepseek"
         # Add more provider detections as needed
         


### PR DESCRIPTION
fix: the parameter enable_thinking is unknown in standard OpenAI API interface, but it is supported by DeepSeek. Gemini supports another parameter reasoning_effort as the deep reasoning.

The updated code has been testified and the results are shown as the screenshots below.

<img width="1085" height="871" alt="DeepSeek_Screenshot" src="https://github.com/user-attachments/assets/33ae95d5-cff1-4ffa-a0e9-9fdb532c6f71" />
<img width="993" height="867" alt="Gemini_Screenshot" src="https://github.com/user-attachments/assets/242d64f0-07ba-41e6-bad5-9c1076f046a7" />
<img width="1136" height="420" alt="Issue_Screenshot" src="https://github.com/user-attachments/assets/3dd57ccf-787f-4ad0-b76b-6ea8236dfb24" />
<img width="554" height="866" alt="OpenAI_Screenshot" src="https://github.com/user-attachments/assets/84eec5d4-bd03-464c-9056-def9510eb384" />
