### PR TITLE
docs: add MiniMax LLM provider configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,21 @@ asyncio.run(main())
   - References: https://github.com/BurntSushi/ripgrep | https://github.com/phiresky/ripgrep-all
 - Replace `"your-api-key"`, `"your-base-url"`, `"your-model-name"` and `/path/to/documents` with your actual values.
 
+<details>
+<summary><b>Using with MiniMax</b></summary>
+
+```python
+from sirchmunk.llm import OpenAIChat
+
+llm = OpenAIChat(
+    api_key="your-minimax-api-key",
+    base_url="https://api.minimax.io/v1",
+    model="MiniMax-M2.5"           # or "MiniMax-M2.5-highspeed"
+)
+```
+
+</details>
+
 
 ### Command Line Interface
 
@@ -814,10 +829,23 @@ Sirchmunk takes an **indexless approach**:
 <details>
 <summary><b>What LLM providers are supported?</b></summary>
 
-Any OpenAI-compatible API endpoint, including (but not limited too):
+Any OpenAI-compatible API endpoint, including (but not limited to):
 - OpenAI (GPT-5.2, ...)
+- [MiniMax](https://platform.minimax.io) (MiniMax-M2.5, MiniMax-M2.5-highspeed)
+- DeepSeek, Moonshot, Mistral, Groq, Together AI, Cohere
+- Google Gemini, Zhipu (GLM), Baichuan, Yi, SiliconFlow, Volcengine
+- Azure OpenAI
 - Local models served via Ollama, llama.cpp, vLLM, SGLang etc.
 - Claude via API proxy
+
+To use MiniMax, configure:
+```bash
+LLM_BASE_URL=https://api.minimax.io/v1
+LLM_API_KEY=your-minimax-api-key
+LLM_MODEL_NAME=MiniMax-M2.5
+```
+
+For more details, see [MiniMax OpenAI-Compatible API](https://platform.minimax.io/docs/api-reference/text-openai-api).
 
 </details>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -259,6 +259,22 @@ asyncio.run(main())
   - 参考：https://github.com/BurntSushi/ripgrep | https://github.com/phiresky/ripgrep-all
 - 将 `"your-api-key"`、`"your-base-url"`、`"your-model-name"` 和 `/path/to/documents` 替换为实际值。
 
+<details>
+<summary><b>使用 MiniMax</b></summary>
+
+```python
+from sirchmunk.llm import OpenAIChat
+
+llm = OpenAIChat(
+    api_key="your-minimax-api-key",
+    base_url="https://api.minimax.io/v1",     # 海外版
+    # base_url="https://api.minimaxi.com/v1", # 国内版
+    model="MiniMax-M2.5"                       # 或 "MiniMax-M2.5-highspeed"
+)
+```
+
+</details>
+
 
 ### 命令行界面
 
@@ -814,8 +830,22 @@ Sirchmunk 采用 **无索引** 方法：
 
 任何 OpenAI 兼容 API 端点，包括但不限于：
 - OpenAI（GPT-5.2, ...）
+- [MiniMax](https://platform.minimax.io)（MiniMax-M2.5、MiniMax-M2.5-highspeed）
+- DeepSeek、Moonshot、Mistral、Groq、Together AI、Cohere
+- Google Gemini、智谱（GLM）、百川、零一万物、硅基流动、火山引擎
+- Azure OpenAI
 - 通过 Ollama、llama.cpp、vLLM、SGLang 等托管的本地模型
 - 通过 API 代理接入的 Claude
+
+使用 MiniMax 的配置示例：
+```bash
+LLM_BASE_URL=https://api.minimax.io/v1        # 海外版
+# LLM_BASE_URL=https://api.minimaxi.com/v1    # 国内版
+LLM_API_KEY=your-minimax-api-key
+LLM_MODEL_NAME=MiniMax-M2.5
+```
+
+详见 [MiniMax OpenAI 兼容 API 文档](https://platform.minimax.io/docs/api-reference/text-openai-api)。
 
 </details>
 

--- a/config/env.example
+++ b/config/env.example
@@ -4,12 +4,18 @@
 
 # ===== LLM Settings =====
 # LLM API base URL (OpenAI-compatible endpoint)
+# Supported providers: OpenAI, MiniMax, DeepSeek, Moonshot, Gemini, Groq, etc.
+# Examples:
+#   OpenAI:   https://api.openai.com/v1
+#   MiniMax:  https://api.minimax.io/v1  (or https://api.minimaxi.com/v1 for China)
+#   DeepSeek: https://api.deepseek.com/v1
 LLM_BASE_URL=https://api.openai.com/v1
 
 # LLM API key (REQUIRED - get from your LLM provider)
 LLM_API_KEY=
 
 # LLM model name
+# Examples: gpt-5.2, MiniMax-M2.5, MiniMax-M2.5-highspeed, deepseek-chat
 LLM_MODEL_NAME=gpt-5.2
 
 # LLM request timeout in seconds

--- a/docker/README.md
+++ b/docker/README.md
@@ -47,8 +47,8 @@ docker run -d \
 | Parameter | Required | Default | Description |
 |---|---|---|---|
 | `-e LLM_API_KEY` | **Yes** | | API key from your LLM provider |
-| `-e LLM_BASE_URL` | No | `https://api.openai.com/v1` | OpenAI-compatible API endpoint |
-| `-e LLM_MODEL_NAME` | No | `gpt-5.2` | LLM model name |
+| `-e LLM_BASE_URL` | No | `https://api.openai.com/v1` | OpenAI-compatible API endpoint (e.g., `https://api.minimax.io/v1` for MiniMax) |
+| `-e LLM_MODEL_NAME` | No | `gpt-5.2` | LLM model name (e.g., `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`) |
 | `-e LLM_TIMEOUT` | No | `60.0` | LLM request timeout in seconds |
 | `-e UI_THEME` | No | `light` | WebUI theme (`light` / `dark`) |
 | `-e UI_LANGUAGE` | No | `en` | WebUI language (`en` / `zh`) |

--- a/src/sirchmunk/api/settings.py
+++ b/src/sirchmunk/api/settings.py
@@ -173,7 +173,10 @@ def get_current_env_variables() -> Dict[str, Any]:
         "LLM_BASE_URL": {
             "value": os.getenv("LLM_BASE_URL", _DEFAULT_LLM_BASE_URL),
             "default": _DEFAULT_LLM_BASE_URL,
-            "description": "Base URL for LLM API (OpenAI-compatible endpoint)",
+            "description": "Base URL for LLM API (OpenAI-compatible endpoint). "
+                           "Examples: https://api.openai.com/v1, "
+                           "https://api.minimax.io/v1, "
+                           "https://api.deepseek.com/v1",
             "category": "llm"
         },
         "LLM_API_KEY": {
@@ -186,7 +189,8 @@ def get_current_env_variables() -> Dict[str, Any]:
         "LLM_MODEL_NAME": {
             "value": os.getenv("LLM_MODEL_NAME", _DEFAULT_LLM_MODEL_NAME),
             "default": _DEFAULT_LLM_MODEL_NAME,
-            "description": "Model name for LLM",
+            "description": "Model name for LLM. "
+                           "Examples: gpt-5.2, MiniMax-M2.5, deepseek-chat",
             "category": "llm"
         },
         "GREP_CONCURRENT_LIMIT": {


### PR DESCRIPTION
## Summary

Sirchmunk already supports MiniMax out of the box (via its OpenAI-compatible provider registry), but the documentation doesn't mention it. This PR adds clear configuration examples so users can get started with MiniMax quickly.

- **README / README_zh**: Added MiniMax configuration snippet to the FAQ ("Which LLM providers are supported?") and a dedicated collapsible "Using with MiniMax" quick-start section with Python SDK example
- **config/env.example**: Added commented provider URL examples (OpenAI, MiniMax, DeepSeek) and model name examples
- **docker/README.md**: Added MiniMax examples to `LLM_BASE_URL` and `LLM_MODEL_NAME` parameter descriptions
- **src/sirchmunk/api/settings.py**: Added MiniMax/DeepSeek URL and model examples to setting descriptions

## Why MiniMax?

[MiniMax](https://www.minimax.io/) offers high-performance LLMs (MiniMax-M2.5, MiniMax-M2.5-highspeed) with a 204,800-token context window and an OpenAI-compatible API. Users can switch to MiniMax by changing only three environment variables — no code changes needed.

## Test plan

- [x] Verified MiniMax is already registered in `openai_chat.py` provider registry — no code changes required
- [x] Confirmed all documentation edits render correctly in Markdown
- [x] No functional code changes; documentation only