### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ from sirchmunk.llm import OpenAIChat
 llm = OpenAIChat(
     api_key="your-minimax-api-key",
     base_url="https://api.minimax.io/v1",
-    model="MiniMax-M2.5"           # or "MiniMax-M2.5-highspeed"
+    model="MiniMax-M2.7"           # or "MiniMax-M2.7-highspeed"
 )
 ```
 
@@ -831,7 +831,7 @@ Sirchmunk takes an **indexless approach**:
 
 Any OpenAI-compatible API endpoint, including (but not limited to):
 - OpenAI (GPT-5.2, ...)
-- [MiniMax](https://platform.minimax.io) (MiniMax-M2.5, MiniMax-M2.5-highspeed)
+- [MiniMax](https://platform.minimax.io) (MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5)
 - DeepSeek, Moonshot, Mistral, Groq, Together AI, Cohere
 - Google Gemini, Zhipu (GLM), Baichuan, Yi, SiliconFlow, Volcengine
 - Azure OpenAI
@@ -842,7 +842,7 @@ To use MiniMax, configure:
 ```bash
 LLM_BASE_URL=https://api.minimax.io/v1
 LLM_API_KEY=your-minimax-api-key
-LLM_MODEL_NAME=MiniMax-M2.5
+LLM_MODEL_NAME=MiniMax-M2.7
 ```
 
 For more details, see [MiniMax OpenAI-Compatible API](https://platform.minimax.io/docs/api-reference/text-openai-api).

--- a/README_zh.md
+++ b/README_zh.md
@@ -269,7 +269,7 @@ llm = OpenAIChat(
     api_key="your-minimax-api-key",
     base_url="https://api.minimax.io/v1",     # 海外版
     # base_url="https://api.minimaxi.com/v1", # 国内版
-    model="MiniMax-M2.5"                       # 或 "MiniMax-M2.5-highspeed"
+    model="MiniMax-M2.7"                       # 或 "MiniMax-M2.7-highspeed"
 )
 ```
 
@@ -830,7 +830,7 @@ Sirchmunk 采用 **无索引** 方法：
 
 任何 OpenAI 兼容 API 端点，包括但不限于：
 - OpenAI（GPT-5.2, ...）
-- [MiniMax](https://platform.minimax.io)（MiniMax-M2.5、MiniMax-M2.5-highspeed）
+- [MiniMax](https://platform.minimax.io)（MiniMax-M2.7、MiniMax-M2.7-highspeed、MiniMax-M2.5）
 - DeepSeek、Moonshot、Mistral、Groq、Together AI、Cohere
 - Google Gemini、智谱（GLM）、百川、零一万物、硅基流动、火山引擎
 - Azure OpenAI
@@ -842,7 +842,7 @@ Sirchmunk 采用 **无索引** 方法：
 LLM_BASE_URL=https://api.minimax.io/v1        # 海外版
 # LLM_BASE_URL=https://api.minimaxi.com/v1    # 国内版
 LLM_API_KEY=your-minimax-api-key
-LLM_MODEL_NAME=MiniMax-M2.5
+LLM_MODEL_NAME=MiniMax-M2.7
 ```
 
 详见 [MiniMax OpenAI 兼容 API 文档](https://platform.minimax.io/docs/api-reference/text-openai-api)。

--- a/config/env.example
+++ b/config/env.example
@@ -15,7 +15,7 @@ LLM_BASE_URL=https://api.openai.com/v1
 LLM_API_KEY=
 
 # LLM model name
-# Examples: gpt-5.2, MiniMax-M2.5, MiniMax-M2.5-highspeed, deepseek-chat
+# Examples: gpt-5.2, MiniMax-M2.7, MiniMax-M2.7-highspeed, deepseek-chat
 LLM_MODEL_NAME=gpt-5.2
 
 # LLM request timeout in seconds

--- a/docker/README.md
+++ b/docker/README.md
@@ -48,7 +48,7 @@ docker run -d \
 |---|---|---|---|
 | `-e LLM_API_KEY` | **Yes** | | API key from your LLM provider |
 | `-e LLM_BASE_URL` | No | `https://api.openai.com/v1` | OpenAI-compatible API endpoint (e.g., `https://api.minimax.io/v1` for MiniMax) |
-| `-e LLM_MODEL_NAME` | No | `gpt-5.2` | LLM model name (e.g., `MiniMax-M2.5`, `MiniMax-M2.5-highspeed`) |
+| `-e LLM_MODEL_NAME` | No | `gpt-5.2` | LLM model name (e.g., `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`) |
 | `-e LLM_TIMEOUT` | No | `60.0` | LLM request timeout in seconds |
 | `-e UI_THEME` | No | `light` | WebUI theme (`light` / `dark`) |
 | `-e UI_LANGUAGE` | No | `en` | WebUI language (`en` / `zh`) |

--- a/src/sirchmunk/api/settings.py
+++ b/src/sirchmunk/api/settings.py
@@ -190,7 +190,7 @@ def get_current_env_variables() -> Dict[str, Any]:
             "value": os.getenv("LLM_MODEL_NAME", _DEFAULT_LLM_MODEL_NAME),
             "default": _DEFAULT_LLM_MODEL_NAME,
             "description": "Model name for LLM. "
-                           "Examples: gpt-5.2, MiniMax-M2.5, deepseek-chat",
+                           "Examples: gpt-5.2, MiniMax-M2.7, deepseek-chat",
             "category": "llm"
         },
         "GREP_CONCURRENT_LIMIT": {


### PR DESCRIPTION
## Summary
Upgrade MiniMax model references to the latest M2.7 as the recommended default model.

## Changes
- Update MiniMax-M2.5 references to MiniMax-M2.7 as the recommended model in documentation and config
- Add MiniMax-M2.7-highspeed as the high-speed alternative
- Keep MiniMax-M2.5 listed as an available alternative in provider lists
- Updated files: README.md, README_zh.md, docker/README.md, config/env.example, settings.py

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities, replacing M2.5 as the recommended default.

## Testing
- All changes are documentation/config string updates only (no logic changes)
- Verified no MiniMax M2.5-only references remain as defaults
- Provider detection logic (openai_chat.py) unchanged