### PR TITLE
fix paths for api/v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,12 @@ When the server is running (`sirchmunk serve` or `sirchmunk web serve`), the Sea
 <details>
 <summary><b>cURL Examples</b></summary>
 
+**`paths` rules (same for `/search` and `/search/stream`):**
+
+- Type: **a single string** or **an array of strings** (`"paths": "/one/dir"` or `"paths": ["/a", "/b"]`).
+- If you **omit** `paths`, send **`null`**, **`""`**, **`[]`**, or only blank strings, the server uses **`SIRCHMUNK_SEARCH_PATHS`** from its environment (typically set in `~/.sirchmunk/.env`, loaded at startup). If that is unset too, search falls back to the server process **current working directory**.
+- **Priority:** explicit non-empty request `paths` → `SIRCHMUNK_SEARCH_PATHS` → cwd.
+
 ```bash
 # FAST mode (default, greedy search with 2 LLM calls)
 curl -X POST http://localhost:8584/api/v1/search \
@@ -684,6 +690,19 @@ curl -X POST http://localhost:8584/api/v1/search \
     "query": "How does authentication work?",
     "paths": ["/path/to/project"]
   }'
+
+# Single path as a string (equivalent to a one-element list)
+curl -X POST http://localhost:8584/api/v1/search \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "How does authentication work?",
+    "paths": "/path/to/project"
+  }'
+
+# Omit paths — use SIRCHMUNK_SEARCH_PATHS from ~/.sirchmunk/.env on the server
+curl -X POST http://localhost:8584/api/v1/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "How does authentication work?"}'
 
 # DEEP mode (comprehensive analysis with Monte Carlo sampling)
 curl -X POST http://localhost:8584/api/v1/search \
@@ -703,7 +722,7 @@ curl -X POST http://localhost:8584/api/v1/search \
     "mode": "FILENAME_ONLY"
   }'
 
-# Full parameters
+# Full parameters (see Request Parameters table)
 curl -X POST http://localhost:8584/api/v1/search \
   -H "Content-Type: application/json" \
   -d '{
@@ -712,7 +731,7 @@ curl -X POST http://localhost:8584/api/v1/search \
     "mode": "DEEP",
     "max_depth": 10,
     "top_k_files": 20,
-    "keyword_levels": 3,
+    "max_loops": 10,
     "include_patterns": ["*.py", "*.java"],
     "exclude_patterns": ["*test*", "*__pycache__*"],
     "return_context": true
@@ -743,7 +762,9 @@ response = requests.post(
 
 data = response.json()
 if data["success"]:
-    print(data["data"]["result"])
+    payload = data.get("data") or {}
+    # API returns type "summary" | "files" | "context"
+    print(payload.get("summary", payload))
 ```
 
 **Using `httpx` (async):**
@@ -758,11 +779,14 @@ async def search():
             "http://localhost:8584/api/v1/search",
             json={
                 "query": "find all API endpoints",
+                # Optional: omit "paths" to use server SIRCHMUNK_SEARCH_PATHS
                 "paths": ["/path/to/project"],
             }
         )
         data = resp.json()
-        print(data["data"]["result"])
+        if data.get("success"):
+            p = data.get("data") or {}
+            print(p.get("summary", p))
 
 asyncio.run(search())
 ```
@@ -784,7 +808,8 @@ const response = await fetch("http://localhost:8584/api/v1/search", {
 
 const data = await response.json();
 if (data.success) {
-  console.log(data.data.result);
+  const p = data.data || {};
+  console.log(p.summary ?? p);
 }
 ```
 
@@ -793,7 +818,7 @@ if (data.success) {
 <details>
 <summary><b>SSE streaming search (<code>/api/v1/search/stream</code>)</b></summary>
 
-Use this endpoint when you need **real-time search logs** (same pipeline as `POST /api/v1/search`). The response is **`text/event-stream`** (Server-Sent Events). The JSON body is identical to `/api/v1/search`.
+Use this endpoint when you need **real-time search logs** (same pipeline as `POST /api/v1/search`). The response is **`text/event-stream`** (Server-Sent Events). The JSON body is identical to `/api/v1/search` (**`paths`** optional; string or array — see cURL section above).
 
 **Event types**
 
@@ -953,13 +978,13 @@ await searchStream("http://localhost:8584", {
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `query` | `string` | *required* | Search query or question |
-| `paths` | `string[]` | *required* | Directories or files to search (min 1); falls back to `SIRCHMUNK_SEARCH_PATHS` if unset |
+| `paths` | `string` \| `string[]` | *optional* | One path or many. Omit / `null` / `""` / `[]` / only blanks → server `SIRCHMUNK_SEARCH_PATHS` (e.g. `~/.sirchmunk/.env`), then cwd. Request paths override env. |
 | `mode` | `string` | `"FAST"` | `FAST`, `DEEP`, or `FILENAME_ONLY` |
 | `enable_dir_scan` | `bool` | `true` | Enable directory scanning (FAST/DEEP) for file discovery |
 | `max_depth` | `int` | `null` | Maximum directory depth |
 | `top_k_files` | `int` | `null` | Number of top files to return |
+| `max_loops` | `int` | `null` | Maximum ReAct iterations (DEEP mode) |
 | `max_token_budget` | `int` | `null` | LLM token budget (DEEP mode, default 128K) |
-| `keyword_levels` | `int` | `null` | Keyword granularity levels |
 | `include_patterns` | `string[]` | `null` | File glob patterns to include |
 | `exclude_patterns` | `string[]` | `null` | File glob patterns to exclude |
 | `return_context` | `bool` | `false` | Return SearchContext with cluster and telemetry |

--- a/README_zh.md
+++ b/README_zh.md
@@ -675,6 +675,12 @@ KnowledgeCluster 是一个丰富标注的对象，完整记录了单次搜索周
 <details>
 <summary><b>cURL 示例</b></summary>
 
+**`paths` 规则（`/search` 与 `/search/stream` 相同）：**
+
+- **可选**。类型：**单个字符串**或**字符串数组**（`"paths": "/一个目录"` 或 `"paths": ["/a", "/b"]`）。
+- **不传**、**`null`**、**`""`**、**`[]`**，或列表里全是空白项时，使用服务器环境变量 **`SIRCHMUNK_SEARCH_PATHS`**（一般在 `~/.sirchmunk/.env` 中配置，服务启动时加载）。若未设置，则回退到服务进程**当前工作目录**。
+- **优先级：** 请求里非空的 `paths` → `SIRCHMUNK_SEARCH_PATHS` → cwd。
+
 ```bash
 # FAST 模式（默认，贪心搜索，2 次 LLM 调用）
 curl -X POST http://localhost:8584/api/v1/search \
@@ -683,6 +689,19 @@ curl -X POST http://localhost:8584/api/v1/search \
     "query": "认证是如何工作的？",
     "paths": ["/path/to/project"]
   }'
+
+# 单个路径用字符串（等价于单元素数组）
+curl -X POST http://localhost:8584/api/v1/search \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "认证是如何工作的？",
+    "paths": "/path/to/project"
+  }'
+
+# 省略 paths — 使用服务器上 ~/.sirchmunk/.env 中的 SIRCHMUNK_SEARCH_PATHS
+curl -X POST http://localhost:8584/api/v1/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "认证是如何工作的？"}'
 
 # DEEP 模式（蒙特卡洛证据采样全面分析）
 curl -X POST http://localhost:8584/api/v1/search \
@@ -702,7 +721,7 @@ curl -X POST http://localhost:8584/api/v1/search \
     "mode": "FILENAME_ONLY"
   }'
 
-# 完整参数示例
+# 完整参数（详见下表「请求参数说明」）
 curl -X POST http://localhost:8584/api/v1/search \
   -H "Content-Type: application/json" \
   -d '{
@@ -711,7 +730,7 @@ curl -X POST http://localhost:8584/api/v1/search \
     "mode": "DEEP",
     "max_depth": 10,
     "top_k_files": 20,
-    "keyword_levels": 3,
+    "max_loops": 10,
     "include_patterns": ["*.py", "*.java"],
     "exclude_patterns": ["*test*", "*__pycache__*"],
     "return_context": true
@@ -742,7 +761,8 @@ response = requests.post(
 
 data = response.json()
 if data["success"]:
-    print(data["data"]["result"])
+    payload = data.get("data") or {}
+    print(payload.get("summary", payload))
 ```
 
 **使用 `httpx`（异步）：**
@@ -757,11 +777,14 @@ async def search():
             "http://localhost:8584/api/v1/search",
             json={
                 "query": "查找所有 API 端点",
+                # 可选：省略 paths 时使用服务端 SIRCHMUNK_SEARCH_PATHS
                 "paths": ["/path/to/project"],
             }
         )
         data = resp.json()
-        print(data["data"]["result"])
+        if data.get("success"):
+            p = data.get("data") or {}
+            print(p.get("summary", p))
 
 asyncio.run(search())
 ```
@@ -783,7 +806,8 @@ const response = await fetch("http://localhost:8584/api/v1/search", {
 
 const data = await response.json();
 if (data.success) {
-  console.log(data.data.result);
+  const p = data.data || {};
+  console.log(p.summary ?? p);
 }
 ```
 
@@ -792,7 +816,7 @@ if (data.success) {
 <details>
 <summary><b>SSE 流式搜索（<code>/api/v1/search/stream</code>）</b></summary>
 
-需要 **实时查看搜索过程日志** 时使用本接口（检索流程与 `POST /api/v1/search` 一致）。响应类型为 **`text/event-stream`**（Server-Sent Events）。请求 JSON 与 `/api/v1/search` **完全相同**。
+需要 **实时查看搜索过程日志** 时使用本接口（检索流程与 `POST /api/v1/search` 一致）。响应类型为 **`text/event-stream`**（Server-Sent Events）。请求 JSON 与 `/api/v1/search` **完全相同**（**`paths`** 可选；可为字符串或数组，见上文 cURL 说明）。
 
 **事件类型**
 
@@ -952,13 +976,13 @@ await searchStream("http://localhost:8584", {
 | 参数 | 类型 | 默认值 | 说明 |
 |------|------|--------|------|
 | `query` | `string` | *必填* | 搜索查询或问题 |
-| `paths` | `string[]` | *必填* | 搜索的目录或文件（至少 1 个）；未设置时回退到 `SIRCHMUNK_SEARCH_PATHS` |
+| `paths` | `string` \| `string[]` | *可选* | 单路径或多路径。省略 / `null` / `""` / `[]` / 仅空白 → 使用服务端 `SIRCHMUNK_SEARCH_PATHS`（如 `~/.sirchmunk/.env`），再回退 cwd。请求中的路径优先于环境变量。 |
 | `mode` | `string` | `"FAST"` | `FAST`、`DEEP` 或 `FILENAME_ONLY` |
 | `enable_dir_scan` | `bool` | `true` | 是否启用目录扫描（FAST/DEEP）以发现文件 |
 | `max_depth` | `int` | `null` | 最大目录深度 |
 | `top_k_files` | `int` | `null` | 返回的文件数量 |
+| `max_loops` | `int` | `null` | ReAct 最大迭代次数（DEEP 模式） |
 | `max_token_budget` | `int` | `null` | LLM token 预算（DEEP 模式，默认 128K） |
-| `keyword_levels` | `int` | `null` | 关键词粒度层级 |
 | `include_patterns` | `string[]` | `null` | 文件 glob 匹配模式（包含） |
 | `exclude_patterns` | `string[]` | `null` | 文件 glob 匹配模式（排除） |
 | `return_context` | `bool` | `false` | 返回完整 SearchContext（含 KnowledgeCluster 和遥测数据） |

--- a/src/sirchmunk/api/search.py
+++ b/src/sirchmunk/api/search.py
@@ -18,7 +18,7 @@ import logging
 import os
 import time
 import uuid
-from typing import AsyncGenerator, List, Literal, Optional
+from typing import AsyncGenerator, List, Literal, Optional, Union
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
@@ -40,9 +40,16 @@ router = APIRouter(prefix="/api/v1", tags=["search"])
 class SearchRequest(BaseModel):
     """Request model for search endpoint."""
     query: str = Field(..., description="Search query or question")
-    paths: Optional[List[str]] = Field(
+    paths: Optional[Union[str, List[str]]] = Field(
         default=None,
-        description="Paths to search (directories or files). Falls back to configured default or cwd."
+        description=(
+            "Directory or file path(s) to search: a single string or a list of strings. "
+            "Omit this field, or pass null, empty string '', empty list [], or only "
+            "whitespace / empty entries, to use SIRCHMUNK_SEARCH_PATHS from the server "
+            "environment (~/.sirchmunk/.env when loaded). Explicit non-empty paths always "
+            "take priority over the environment default (then AgenticSearch falls back to "
+            "cwd if env is also unset)."
+        ),
     )
     mode: Literal["DEEP", "FAST", "FILENAME_ONLY"] = Field(
         default="FAST",
@@ -189,6 +196,44 @@ def _create_search_instance(log_callback=None) -> AgenticSearch:
 
 
 # ===================================================================
+#  Path coercion (HTTP API contract)
+# ===================================================================
+
+def _normalize_api_paths(
+    paths: Optional[Union[str, List[str]]],
+) -> Optional[Union[str, List[str]]]:
+    """Return ``None`` when the client did not supply usable paths.
+
+    ``None``, missing key, ``""``, ``[]``, or lists of only blank strings
+    all mean: defer to ``AgenticSearch._resolve_paths`` (explicit request
+    param absent → ``SIRCHMUNK_SEARCH_PATHS`` → cwd).
+
+    A single non-empty path may be returned as a bare ``str`` (one path)
+    or remains a one-element list from JSON; both are accepted by
+    ``AgenticSearch.search``.
+    """
+    if paths is None:
+        return None
+    if isinstance(paths, str):
+        stripped = paths.strip()
+        return None if stripped == "" else stripped
+    if not isinstance(paths, list):
+        return None
+    cleaned: List[str] = []
+    for p in paths:
+        if not isinstance(p, str):
+            continue
+        s = p.strip()
+        if s:
+            cleaned.append(s)
+    if not cleaned:
+        return None
+    if len(cleaned) == 1:
+        return cleaned[0]
+    return cleaned
+
+
+# ===================================================================
 #  SSE helpers
 # ===================================================================
 
@@ -201,7 +246,7 @@ def _sse_event(event: str, data: dict) -> str:
 def _build_search_kwargs(request: SearchRequest) -> dict:
     kwargs = {
         "query": request.query,
-        "paths": request.paths,
+        "paths": _normalize_api_paths(request.paths),
         "mode": request.mode,
         "enable_dir_scan": request.enable_dir_scan,
         "return_context": request.return_context,
@@ -243,11 +288,15 @@ async def execute_search(request: SearchRequest) -> SearchResponse:
     try:
         async with _search_semaphore:
             searcher = _get_search_instance()
-            logger.info(
-                "Executing search: query='%s', mode=%s, paths=%s",
-                request.query, request.mode, request.paths,
+            kwargs = _build_search_kwargs(request)
+            logger.debug(
+                "Executing search: query='%s', mode=%s, paths(raw)=%s paths(resolved)=%s",
+                request.query,
+                request.mode,
+                request.paths,
+                kwargs.get("paths"),
             )
-            result = await searcher.search(**_build_search_kwargs(request))
+            result = await searcher.search(**kwargs)
 
         return SearchResponse(success=True, data=_format_result(result, request))
 
@@ -316,11 +365,15 @@ async def execute_search_stream(request: SearchRequest, http_request: Request):
         try:
             async with _search_semaphore:
                 searcher = _create_search_instance(log_callback=_log_callback)
-                logger.info(
-                    "[stream:%s] Starting search: query='%s' mode=%s",
-                    request_id, request.query, request.mode,
+                skwargs = _build_search_kwargs(request)
+                logger.debug(
+                    "[stream:%s] Starting search: query='%s' mode=%s paths(resolved)=%s",
+                    request_id,
+                    request.query,
+                    request.mode,
+                    skwargs.get("paths"),
                 )
-                result = await searcher.search(**_build_search_kwargs(request))
+                result = await searcher.search(**skwargs)
 
             formatted = _format_result(result, request)
             await log_queue.put(("result", {"success": True, "data": formatted}))


### PR DESCRIPTION
* **Flexible `paths` parameter**: The `/api/v1/search` and `/api/v1/search/stream` endpoints now accept the `paths` parameter as either a single string or an array of strings. This provides more flexibility for specifying search directories or files.
* **Optional `paths` parameter with fallback logic**: The `paths` parameter is now optional. If omitted, `null`, an empty string, an empty list, or a list containing only blank strings, the server will fall back to using the `SIRCHMUNK_SEARCH_PATHS` environment variable. If that is also unset, it defaults to the server process's current working directory. Explicit non-empty paths in the request take precedence.
* **API Documentation Updates**: The `README.md` and `README_zh.md` files have been extensively updated to reflect the new `paths` parameter behavior, including detailed rules, new cURL examples, and modifications to Python and JavaScript client examples to correctly handle API responses.
* **Parameter Renaming**: The `keyword_levels` parameter has been replaced with `max_loops` in the API documentation, indicating a change in the underlying search mechanism for DEEP mode.
* **Internal Path Normalization**: A new internal utility function, `_normalize_api_paths`, was introduced to consistently process and resolve the `paths` parameter received from API requests, ensuring proper fallback logic.