### PR TITLE
Improve LLM rank candidate selection logic

### DIFF
--- a/src/sirchmunk/scan/dir_scanner.py
+++ b/src/sirchmunk/scan/dir_scanner.py
@@ -9,6 +9,7 @@ ranks the most promising document candidates for a given query.
 This is a *zero-index* approach — no pre-built vector indices required.
 """
 import asyncio
+import random
 import json
 import logging
 import mimetypes
@@ -352,7 +353,10 @@ class DirectoryScanner:
 
         t_start = datetime.now()
 
-        candidates_to_rank = scan_result.candidates[:top_k]
+        if len(scan_result.candidates) > top_k:
+            candidates_to_rank = random.sample(scan_result.candidates, top_k)
+        else:
+            candidates_to_rank = scan_result.candidates
 
         root_dir = self._find_common_root(candidates_to_rank)
         dir_tree = self._build_dir_tree(candidates_to_rank, root_dir)


### PR DESCRIPTION
## Description
This PR addresses the recall limitation in `DirectoryScanner.rank`. Currently, the system only sends the first 20 candidates (fixed prefix) to the LLM for ranking, which introduces significant position bias.

By switching from `[:top_k]` to `random.sample()`, we ensure a broader coverage of the directory structure without increasing LLM context costs.

For the detailed motivation behind this PR, please see the related issue.


## Related Issue
Fixes [# 63](https://github.com/modelscope/sirchmunk/issues/63)

## Changes
- Modified `DirectoryScanner.rank` to use random sampling instead of fixed prefix slicing.
- Added safety check for cases where candidate count is less than `top_k`.