### PR TITLE
fix(mcp): expand ~ in path env vars after dotenv load

### DIFF
--- a/src/sirchmunk_mcp/config.py
+++ b/src/sirchmunk_mcp/config.py
@@ -223,9 +223,21 @@ class Config(BaseModel):
         work_path = Path(os.getenv("SIRCHMUNK_WORK_PATH", str(Path.home() / ".sirchmunk")))
         work_path = work_path.expanduser().resolve()
         env_file = work_path / ".env"
-        
+
         if env_file.exists():
             load_dotenv(env_file, override=False)
+
+        # Expand ~ in path-related env vars after dotenv load, mirroring
+        # sirchmunk.cli._load_env_file. The default .env template uses
+        # `EMBEDDING_CACHE_DIR=${SIRCHMUNK_WORK_PATH}/.cache/models` with
+        # `SIRCHMUNK_WORK_PATH=~/.sirchmunk`; python-dotenv interpolates the
+        # `${...}` but does NOT expand `~`, so downstream consumers that skip
+        # `os.path.expanduser` end up creating a literal `~` directory in the
+        # process CWD. Normalising here once fixes every consumer.
+        for _key in ("SIRCHMUNK_WORK_PATH", "EMBEDDING_CACHE_DIR"):
+            _val = os.environ.get(_key)
+            if _val and "~" in _val:
+                os.environ[_key] = os.path.expanduser(_val)
         
         # LLM configuration
         llm_config = LLMConfig(


### PR DESCRIPTION
## Problem

After `sirchmunk init`, the generated `~/.sirchmunk/.env` contains:

```
SIRCHMUNK_WORK_PATH=~/.sirchmunk
EMBEDDING_CACHE_DIR=${SIRCHMUNK_WORK_PATH}/.cache/models
```

When the MCP server starts via `Config.from_env()` in `src/sirchmunk_mcp/config.py`, `python-dotenv` interpolates `${SIRCHMUNK_WORK_PATH}` but **does not expand `~`**. The result: `os.environ['EMBEDDING_CACHE_DIR']` ends up as the literal string `~/.sirchmunk/.cache/models`.

`sirchmunk.cli._load_env_file` already handles this by re-scanning the two path keys and calling `os.path.expanduser` right after `load_dotenv`. The MCP server's `Config.from_env` does **not**, so any downstream consumer that skips `expanduser` (e.g., `modelscope.snapshot_download` receiving the raw env value) creates a **literal `~` directory under the process CWD** instead of `\$HOME`.

## Symptom

Running the MCP server from any working directory and issuing a `sirchmunk_search` call causes a folder named `~/.sirchmunk/.cache/models/sentence-transformers/...` to appear **inside the current working directory**, alongside the real `\$HOME/.sirchmunk/.cache/`.

In my case this showed up across several of my code repositories (the MCP server was started in each one), polluting unrelated git trees with a literal `~` directory containing a 470MB sentence-transformer model cache.

## Fix

Mirror the expansion loop that already exists in `sirchmunk.cli._load_env_file` right after the MCP config's `load_dotenv` call. Normalising here once fixes every consumer that reads the env vars later, regardless of whether they call `expanduser` themselves.

```python
for _key in ("SIRCHMUNK_WORK_PATH", "EMBEDDING_CACHE_DIR"):
    _val = os.environ.get(_key)
    if _val and "~" in _val:
        os.environ[_key] = os.path.expanduser(_val)
```

The change is 13 lines (including the explanatory comment) in a single file.

## Why this mirrors `cli._load_env_file` instead of extracting a shared helper

I kept the PR minimal on purpose: the two call sites already disagree on a few details (the CLI also has a manual-parsing fallback for when `python-dotenv` is missing, which the MCP path does not need). Extracting a shared utility is a reasonable follow-up but felt out of scope for a bug fix. Happy to open a separate refactor PR if you'd like.

## Alternative considered

Making `sirchmunk init` write an absolute path (e.g. `SIRCHMUNK_WORK_PATH=/Users/alice/.sirchmunk`) would also fix this for new installs. But it would not help users whose `.env` was generated by an earlier version, and it does not address the underlying issue that the MCP config trusts dotenv-interpolated values. The expansion loop is the more defensive fix.

## Test plan

- [x] Manual repro against my own install: before the fix, starting the MCP server from `/tmp/repro` creates `/tmp/repro/~/.sirchmunk/.cache/models/`. After the fix, it creates `/Users/sining/.sirchmunk/.cache/models/` as expected.
- [x] CI (no test suite exists in the repo for `sirchmunk_mcp/config.py`, so no unit test added — happy to scaffold one if maintainers point me at the preferred test layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)