### PR TITLE
[Fix] Hotfix mcp work path

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,11 +375,15 @@ pip install sirchmunk[mcp]
 
 # Initialize (generates .env and mcp_config.json)
 sirchmunk init
+# Optional: use a custom work path
+# sirchmunk init --work-path /path/to/your_work_path
 
 # Edit ~/.sirchmunk/.env with your LLM API key
 
 # Test with MCP Inspector
 npx @modelcontextprotocol/inspector sirchmunk mcp serve
+# Optional: use a custom work path for this MCP run
+# npx @modelcontextprotocol/inspector sirchmunk mcp serve --work-path /path/to/your_work_path
 ```
 
 ### `mcp_config.json` Configuration
@@ -395,7 +399,8 @@ After running `sirchmunk init`, a `~/.sirchmunk/mcp_config.json` file is generat
       "command": "sirchmunk",
       "args": ["mcp", "serve"],
       "env": {
-        "SIRCHMUNK_SEARCH_PATHS": "/path/to/your_docs,/another/path"
+        "SIRCHMUNK_SEARCH_PATHS": "",
+        "SIRCHMUNK_WORK_PATH": "/path/to/your_work_path"
       }
     }
   }
@@ -407,9 +412,11 @@ After running `sirchmunk init`, a `~/.sirchmunk/mcp_config.json` file is generat
 | `command` | The command to start the MCP server. Use full path (e.g. `/path/to/venv/bin/sirchmunk`) if running in a virtual environment. |
 | `args` | Command arguments. `["mcp", "serve"]` starts the MCP server in stdio mode. |
 | `env.SIRCHMUNK_SEARCH_PATHS` | Default document search directories (comma-separated). Supports both English `,` and Chinese `，` as delimiters. When set, these paths are used as default if no `paths` parameter is provided during tool invocation. |
+| `env.SIRCHMUNK_WORK_PATH` | Sets the Sirchmunk working directory used by MCP server (`.env`, cache, knowledge, history). Recommended for persistent MCP clients. |
 
 > **Tip**: MCP Inspector is a great way to test the integration before connecting to your AI assistant.
 > In MCP Inspector: **Connect** → **Tools** → **List Tools** → `sirchmunk_search` → Input parameters (`query` and `paths`, e.g. `["/path/to/your_docs"]`) → **Run Tool**.
+> You can override the working directory temporarily with `sirchmunk mcp serve --work-path /path/to/your_work_path`.
 
 ### Features
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -374,11 +374,15 @@ pip install sirchmunk[mcp]
 
 # 初始化（生成 .env 和 mcp_config.json）
 sirchmunk init
+# 可选：使用自定义工作目录
+# sirchmunk init --work-path /path/to/your_work_path
 
 # 编辑 ~/.sirchmunk/.env 配置 LLM API Key
 
 # 使用 MCP Inspector 测试
 npx @modelcontextprotocol/inspector sirchmunk mcp serve
+# 可选：本次 MCP 运行使用自定义工作目录
+# npx @modelcontextprotocol/inspector sirchmunk mcp serve --work-path /path/to/your_work_path
 ```
 
 ### `mcp_config.json` 配置
@@ -394,7 +398,8 @@ npx @modelcontextprotocol/inspector sirchmunk mcp serve
       "command": "sirchmunk",
       "args": ["mcp", "serve"],
       "env": {
-        "SIRCHMUNK_SEARCH_PATHS": "/path/to/your_docs,/another/path"
+        "SIRCHMUNK_SEARCH_PATHS": "",
+        "SIRCHMUNK_WORK_PATH": "/path/to/your_work_path"
       }
     }
   }
@@ -406,9 +411,11 @@ npx @modelcontextprotocol/inspector sirchmunk mcp serve
 | `command` | 启动 MCP 服务器的命令。如果在虚拟环境中运行，请使用完整路径（如 `/path/to/venv/bin/sirchmunk`）。 |
 | `args` | 命令参数。`["mcp", "serve"]` 以 stdio 模式启动 MCP 服务器。 |
 | `env.SIRCHMUNK_SEARCH_PATHS` | 默认文档搜索目录（逗号分隔）。同时支持英文逗号 `,` 和中文逗号 `，` 作为分隔符。设置后，若工具调用时未提供 `paths` 参数，将使用这些路径作为默认值。 |
+| `env.SIRCHMUNK_WORK_PATH` | 指定 MCP 服务器使用的 Sirchmunk 工作目录（`.env`、缓存、知识库、历史记录）。推荐在持久化 MCP 客户端中配置。 |
 
 > **提示**：MCP Inspector 非常适合在连接 AI 助手之前测试集成是否正常。
 > 在 MCP Inspector 中：**Connect** → **Tools** → **List Tools** → `sirchmunk_search` → 输入参数（`query` 和 `paths`，如 `["/path/to/your_docs"]`）→ **Run Tool**。
+> 也可通过 `sirchmunk mcp serve --work-path /path/to/your_work_path` 临时覆盖工作目录。
 
 ### 特性
 

--- a/config/mcp_config.json
+++ b/config/mcp_config.json
@@ -4,7 +4,8 @@
       "command": "sirchmunk",
       "args": ["mcp", "serve"],
       "env": {
-        "SIRCHMUNK_SEARCH_PATHS": ""
+        "SIRCHMUNK_SEARCH_PATHS": "",
+        "SIRCHMUNK_WORK_PATH": "/path/to/your_work_path"
       }
     }
   }

--- a/src/sirchmunk/cli/cli.py
+++ b/src/sirchmunk/cli/cli.py
@@ -389,20 +389,22 @@ def _run_base_init(work_path: Path) -> int:
     # Generate MCP client config example
     mcp_config_file = work_path / "mcp_config.json"
     if not mcp_config_file.exists():
-        mcp_config_content = """\
-{
-  "mcpServers": {
-    "sirchmunk": {
-      "command": "sirchmunk",
-      "args": ["mcp", "serve"],
-      "env": {
-        "SIRCHMUNK_SEARCH_PATHS": "",
-        "SIRCHMUNK_WORK_PATH": "/path/to/your_work_path"
-      }
-    }
-  }
-}
-"""
+        mcp_config_content = json.dumps(
+            {
+                "mcpServers": {
+                    "sirchmunk": {
+                        "command": "sirchmunk",
+                        "args": ["mcp", "serve"],
+                        "env": {
+                            "SIRCHMUNK_SEARCH_PATHS": "",
+                            "SIRCHMUNK_WORK_PATH": str(work_path),
+                        },
+                    }
+                }
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
         mcp_config_file.write_text(mcp_config_content)
         print(f"  ✓ Generated MCP client config: {mcp_config_file}")
     else:
@@ -1079,14 +1081,13 @@ def _serve_dev_mode(args: argparse.Namespace, work_path: Path) -> int:
 # sirchmunk mcp serve
 # ------------------------------------------------------------------
 
-def _setup_stdio_safe_environment(work_path: Path):
+def _setup_stdio_safe_environment():
     """Configure environment for safe stdio MCP communication.
 
     In MCP stdio mode, stdout is reserved exclusively for JSON-RPC messages.
     Any non-JSON output to stdout will break the protocol.
     """
     os.environ["MODELSCOPE_LOG_LEVEL"] = str(logging.ERROR)
-    os.environ["MODELSCOPE_CACHE"] = str(work_path / ".cache" / "models")
     os.environ["TRANSFORMERS_VERBOSITY"] = "error"
     os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
@@ -1110,6 +1111,9 @@ def cmd_mcp_serve(args: argparse.Namespace) -> int:
             getattr(args, "work_path", None) or str(_get_default_work_path())
         ).expanduser().resolve()
         os.environ["SIRCHMUNK_WORK_PATH"] = str(work_path)
+        # Keep model cache path consistent with the selected work path
+        # for both stdio and HTTP transports.
+        os.environ["MODELSCOPE_CACHE"] = str(work_path / ".cache" / "models")
 
         # Override transport from command-line if specified
         if args.transport:
@@ -1127,7 +1131,7 @@ def cmd_mcp_serve(args: argparse.Namespace) -> int:
         # Set up safe environment BEFORE any sirchmunk imports for stdio mode
         if transport == "stdio":
             os.environ["MCP_TRANSPORT"] = "stdio"
-            _setup_stdio_safe_environment(work_path)
+            _setup_stdio_safe_environment()
 
         # Load .env before importing config (so env vars are available)
         env_file = work_path / ".env"
@@ -1573,7 +1577,7 @@ def run_cmd():
     # Allow --work-path both before and after sub-commands.
     # Sub-command specific --work-path still works as before.
     if getattr(args, "global_work_path", None):
-        if not hasattr(args, "work_path") or getattr(args, "work_path", None) is None:
+        if getattr(args, "work_path", None) is None:
             setattr(args, "work_path", args.global_work_path)
 
     # Handle --version flag

--- a/src/sirchmunk/cli/cli.py
+++ b/src/sirchmunk/cli/cli.py
@@ -1102,6 +1102,12 @@ def cmd_mcp_serve(args: argparse.Namespace) -> int:
         Exit code
     """
     try:
+        # Resolve work path from --work-path or default
+        work_path = Path(
+            getattr(args, "work_path", None) or str(_get_default_work_path())
+        ).expanduser().resolve()
+        os.environ["SIRCHMUNK_WORK_PATH"] = str(work_path)
+
         # Override transport from command-line if specified
         if args.transport:
             os.environ["MCP_TRANSPORT"] = args.transport
@@ -1121,7 +1127,6 @@ def cmd_mcp_serve(args: argparse.Namespace) -> int:
             _setup_stdio_safe_environment()
 
         # Load .env before importing config (so env vars are available)
-        work_path = _get_default_work_path().expanduser().resolve()
         env_file = work_path / ".env"
         if env_file.exists():
             _load_env_file(env_file)
@@ -1492,6 +1497,11 @@ Examples:
     mcp_serve_parser.add_argument("--host", help="Host for HTTP transport (default: localhost)")
     mcp_serve_parser.add_argument("--port", type=int, help="Port for HTTP transport (default: 8080)")
     mcp_serve_parser.add_argument("--log-level", choices=["DEBUG", "INFO", "WARNING", "ERROR"])
+    mcp_serve_parser.add_argument(
+        "--work-path",
+        default=str(_get_default_work_path()),
+        help="Working directory (default: ~/.sirchmunk)",
+    )
     mcp_serve_parser.set_defaults(func=cmd_mcp_serve)
 
     # sirchmunk mcp version

--- a/src/sirchmunk/cli/cli.py
+++ b/src/sirchmunk/cli/cli.py
@@ -396,7 +396,8 @@ def _run_base_init(work_path: Path) -> int:
       "command": "sirchmunk",
       "args": ["mcp", "serve"],
       "env": {
-        "SIRCHMUNK_SEARCH_PATHS": ""
+        "SIRCHMUNK_SEARCH_PATHS": "",
+        "SIRCHMUNK_WORK_PATH": "/path/to/your_work_path"
       }
     }
   }
@@ -1076,14 +1077,14 @@ def _serve_dev_mode(args: argparse.Namespace, work_path: Path) -> int:
 # sirchmunk mcp serve
 # ------------------------------------------------------------------
 
-def _setup_stdio_safe_environment():
+def _setup_stdio_safe_environment(work_path: Path):
     """Configure environment for safe stdio MCP communication.
 
     In MCP stdio mode, stdout is reserved exclusively for JSON-RPC messages.
     Any non-JSON output to stdout will break the protocol.
     """
     os.environ["MODELSCOPE_LOG_LEVEL"] = str(logging.ERROR)
-    os.environ["MODELSCOPE_CACHE"] = os.path.expanduser("~/.sirchmunk/.cache/models")
+    os.environ["MODELSCOPE_CACHE"] = str(work_path / ".cache" / "models")
     os.environ["TRANSFORMERS_VERBOSITY"] = "error"
     os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
@@ -1124,7 +1125,7 @@ def cmd_mcp_serve(args: argparse.Namespace) -> int:
         # Set up safe environment BEFORE any sirchmunk imports for stdio mode
         if transport == "stdio":
             os.environ["MCP_TRANSPORT"] = "stdio"
-            _setup_stdio_safe_environment()
+            _setup_stdio_safe_environment(work_path)
 
         # Load .env before importing config (so env vars are available)
         env_file = work_path / ".env"

--- a/src/sirchmunk/cli/cli.py
+++ b/src/sirchmunk/cli/cli.py
@@ -424,7 +424,9 @@ def cmd_init(args: argparse.Namespace) -> int:
         Exit code (0 for success, non-zero for failure)
     """
     try:
-        work_path = Path(args.work_path).expanduser().resolve()
+        work_path = Path(
+            getattr(args, "work_path", None) or str(_get_default_work_path())
+        ).expanduser().resolve()
 
         print("=" * 60)
         print("  Sirchmunk Initialization")
@@ -1388,6 +1390,12 @@ Examples:
         action="store_true",
         help="Show version and exit",
     )
+    parser.add_argument(
+        "--work-path",
+        dest="global_work_path",
+        default=None,
+        help="Global working directory (can be used before sub-commands).",
+    )
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
@@ -1399,7 +1407,7 @@ Examples:
     )
     init_parser.add_argument(
         "--work-path",
-        default=str(_get_default_work_path()),
+        default=None,
         help="Working directory path (default: ~/.sirchmunk)",
     )
     init_parser.set_defaults(func=cmd_init)
@@ -1416,7 +1424,7 @@ Examples:
     serve_parser.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"])
     serve_parser.add_argument(
         "--work-path",
-        default=str(_get_default_work_path()),
+        default=None,
         help="Working directory (default: ~/.sirchmunk)",
     )
     serve_parser.set_defaults(func=cmd_serve)
@@ -1475,7 +1483,7 @@ Examples:
     web_serve_parser.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"])
     web_serve_parser.add_argument(
         "--work-path",
-        default=str(_get_default_work_path()),
+        default=None,
         help="Working directory (default: ~/.sirchmunk)",
     )
     web_serve_parser.set_defaults(func=cmd_web_serve)
@@ -1500,7 +1508,7 @@ Examples:
     mcp_serve_parser.add_argument("--log-level", choices=["DEBUG", "INFO", "WARNING", "ERROR"])
     mcp_serve_parser.add_argument(
         "--work-path",
-        default=str(_get_default_work_path()),
+        default=None,
         help="Working directory (default: ~/.sirchmunk)",
     )
     mcp_serve_parser.set_defaults(func=cmd_mcp_serve)
@@ -1561,6 +1569,12 @@ def run_cmd():
     """Main entry point for the CLI."""
     parser = create_parser()
     args = parser.parse_args()
+
+    # Allow --work-path both before and after sub-commands.
+    # Sub-command specific --work-path still works as before.
+    if getattr(args, "global_work_path", None):
+        if not hasattr(args, "work_path") or getattr(args, "work_path", None) is None:
+            setattr(args, "work_path", args.global_work_path)
 
     # Handle --version flag
     if args.version:


### PR DESCRIPTION

**Implementation & Logic Updates**
*   **Configurable Working Directory for MCP**: Add `--work-path` CLI argument applicable to `mcp serve` command
*   **Custom Resource Pathing**: Allows users to specify a custom directory for storing environment variables, cache files, and history logs.
*   **CLI Argument Parsing**: Simplified the logic for parsing the new `--work-path` argument.
*   **Dynamic Configuration Generation**: Updated configuration file generation to dynamically populate the actual work path instead of using static placeholders.
*   **Environment Variable Consistency**: Ensured the `MODELSCOPE_CACHE` environment variable is consistently set across all transport modes based on the specified work path.

**Documentation**
*   **Docs Update**: Updated documentation to reflect the new `--work-path` parameter and its usage across supported commands.