### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ from sirchmunk.llm import OpenAIChat
 llm = OpenAIChat(
     api_key="your-minimax-api-key",
     base_url="https://api.minimax.io/v1",
-    model="MiniMax-M2.7"           # or "MiniMax-M2.7-highspeed"
+    model="MiniMax-M3"             # or "MiniMax-M2.7" / "MiniMax-M2.7-highspeed"
 )
 ```
 
@@ -1039,7 +1039,7 @@ Sirchmunk takes an **indexless approach**:
 
 Any OpenAI-compatible API endpoint, including (but not limited to):
 - OpenAI (GPT-5.2, ...)
-- [MiniMax](https://platform.minimax.io) (MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5)
+- [MiniMax](https://platform.minimax.io) (MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed)
 - DeepSeek, Moonshot, Mistral, Groq, Together AI, Cohere
 - Google Gemini, Zhipu (GLM), Baichuan, Yi, SiliconFlow, Volcengine
 - Azure OpenAI
@@ -1050,7 +1050,7 @@ To use MiniMax, configure:
 ```bash
 LLM_BASE_URL=https://api.minimax.io/v1
 LLM_API_KEY=your-minimax-api-key
-LLM_MODEL_NAME=MiniMax-M2.7
+LLM_MODEL_NAME=MiniMax-M3
 ```
 
 For more details, see [MiniMax OpenAI-Compatible API](https://platform.minimax.io/docs/api-reference/text-openai-api).

--- a/README_zh.md
+++ b/README_zh.md
@@ -282,7 +282,7 @@ llm = OpenAIChat(
     api_key="your-minimax-api-key",
     base_url="https://api.minimax.io/v1",     # 海外版
     # base_url="https://api.minimaxi.com/v1", # 国内版
-    model="MiniMax-M2.7"                       # 或 "MiniMax-M2.7-highspeed"
+    model="MiniMax-M3"                         # 或 "MiniMax-M2.7" / "MiniMax-M2.7-highspeed"
 )
 ```
 
@@ -1037,7 +1037,7 @@ Sirchmunk 采用 **无索引** 方法：
 
 任何 OpenAI 兼容 API 端点，包括但不限于：
 - OpenAI（GPT-5.2, ...）
-- [MiniMax](https://platform.minimax.io)（MiniMax-M2.7、MiniMax-M2.7-highspeed、MiniMax-M2.5）
+- [MiniMax](https://platform.minimax.io)（MiniMax-M3、MiniMax-M2.7、MiniMax-M2.7-highspeed）
 - DeepSeek、Moonshot、Mistral、Groq、Together AI、Cohere
 - Google Gemini、智谱（GLM）、百川、零一万物、硅基流动、火山引擎
 - Azure OpenAI
@@ -1049,7 +1049,7 @@ Sirchmunk 采用 **无索引** 方法：
 LLM_BASE_URL=https://api.minimax.io/v1        # 海外版
 # LLM_BASE_URL=https://api.minimaxi.com/v1    # 国内版
 LLM_API_KEY=your-minimax-api-key
-LLM_MODEL_NAME=MiniMax-M2.7
+LLM_MODEL_NAME=MiniMax-M3
 ```
 
 详见 [MiniMax OpenAI 兼容 API 文档](https://platform.minimax.io/docs/api-reference/text-openai-api)。

--- a/config/env.example
+++ b/config/env.example
@@ -15,7 +15,7 @@ LLM_BASE_URL=https://api.openai.com/v1
 LLM_API_KEY=
 
 # LLM model name
-# Examples: gpt-5.2, MiniMax-M2.7, MiniMax-M2.7-highspeed, deepseek-chat
+# Examples: gpt-5.2, MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed, deepseek-chat
 LLM_MODEL_NAME=gpt-5.2
 
 # LLM request timeout in seconds

--- a/docker/README.md
+++ b/docker/README.md
@@ -48,7 +48,7 @@ docker run -d \
 |---|---|---|---|
 | `-e LLM_API_KEY` | **Yes** | | API key from your LLM provider |
 | `-e LLM_BASE_URL` | No | `https://api.openai.com/v1` | OpenAI-compatible API endpoint (e.g., `https://api.minimax.io/v1` for MiniMax) |
-| `-e LLM_MODEL_NAME` | No | `gpt-5.2` | LLM model name (e.g., `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`) |
+| `-e LLM_MODEL_NAME` | No | `gpt-5.2` | LLM model name (e.g., `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`) |
 | `-e LLM_TIMEOUT` | No | `60.0` | LLM request timeout in seconds |
 | `-e UI_THEME` | No | `light` | WebUI theme (`light` / `dark`) |
 | `-e UI_LANGUAGE` | No | `en` | WebUI language (`en` / `zh`) |

--- a/src/sirchmunk/api/settings.py
+++ b/src/sirchmunk/api/settings.py
@@ -194,7 +194,7 @@ def get_current_env_variables() -> Dict[str, Any]:
             "value": os.getenv("LLM_MODEL_NAME", _DEFAULT_LLM_MODEL_NAME),
             "default": _DEFAULT_LLM_MODEL_NAME,
             "description": "Model name for LLM. "
-                           "Examples: gpt-5.2, MiniMax-M2.7, deepseek-chat",
+                           "Examples: gpt-5.2, MiniMax-M3, deepseek-chat",
             "category": "llm"
         },
         "EMBEDDING_MODEL_ID": {


### PR DESCRIPTION
## Summary
Upgrade MiniMax model references to feature the latest M3 model as the suggested default.

## Changes
- Add `MiniMax-M3` as the suggested default in `README.md`, `README_zh.md`, `config/env.example`, `docker/README.md`, and `src/sirchmunk/api/settings.py`
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- Drop the deprecated `MiniMax-M2.5` reference from the supported models list

## Why
MiniMax-M3 is the new flagship model with a 512K context window, 128K max output, and image input support across both OpenAI-compatible and Anthropic-compatible interfaces. Updating the documentation examples helps users land on the latest model out of the box.

## Testing
- Docs/config-only change; no code logic or API URL is modified
- Verified no remaining references to M2.5 / M2.1 / M2 / M1 in the repo