### PR TITLE
feat(llm): register OrcaRouter in the provider profile system

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,25 @@ llm = OpenAIChat(
 
 </details>
 
+<details>
+<summary><b>Using with OrcaRouter</b></summary>
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible router exposing
+200+ models behind a single API key. Model ids use the router's own
+`provider/model` format, e.g. `openai/gpt-4o`:
+
+```python
+from sirchmunk.llm import OpenAIChat
+
+llm = OpenAIChat(
+    api_key="sk-orca-...",
+    base_url="https://api.orcarouter.ai/v1",
+    model="openai/gpt-4o"          # or "openai/gpt-4o-mini" / "deepseek/deepseek-v4-flash"
+)
+```
+
+</details>
+
 
 ### Command Line Interface
 
@@ -1089,6 +1108,7 @@ Sirchmunk takes an **indexless approach**:
 Any OpenAI-compatible API endpoint, including (but not limited to):
 - OpenAI (GPT-5.2, ...)
 - [MiniMax](https://platform.minimax.io) (MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed)
+- [OrcaRouter](https://www.orcarouter.ai) (openai/gpt-4o, openai/gpt-4o-mini, deepseek/deepseek-v4-flash, ...)
 - DeepSeek, Moonshot, Mistral, Groq, Together AI, Cohere
 - Google Gemini, Zhipu (GLM), Baichuan, Yi, SiliconFlow, Volcengine
 - Azure OpenAI
@@ -1103,6 +1123,15 @@ LLM_MODEL_NAME=MiniMax-M3
 ```
 
 For more details, see [MiniMax OpenAI-Compatible API](https://platform.minimax.io/docs/api-reference/text-openai-api).
+
+To use OrcaRouter, configure:
+```bash
+LLM_BASE_URL=https://api.orcarouter.ai/v1
+LLM_API_KEY=your-orcarouter-api-key
+LLM_MODEL_NAME=openai/gpt-4o
+```
+
+OrcaRouter exposes 200+ models (OpenAI, Anthropic, Google, DeepSeek, ...) behind a single API key; model ids use the router's own `provider/model` format (e.g. `openai/gpt-4o`, `deepseek/deepseek-v4-flash`).
 
 </details>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -299,6 +299,25 @@ llm = OpenAIChat(
 
 </details>
 
+<details>
+<summary><b>使用 OrcaRouter</b></summary>
+
+[OrcaRouter](https://www.orcarouter.ai) 是 OpenAI 兼容路由器，一个 API key 即可
+访问 200+ 模型。模型 id 使用路由器自身的 `provider/model` 格式，例如
+`openai/gpt-4o`：
+
+```python
+from sirchmunk.llm import OpenAIChat
+
+llm = OpenAIChat(
+    api_key="sk-orca-...",
+    base_url="https://api.orcarouter.ai/v1",
+    model="openai/gpt-4o"          # 或 "openai/gpt-4o-mini" / "deepseek/deepseek-v4-flash"
+)
+```
+
+</details>
+
 
 ### 命令行界面
 
@@ -1087,6 +1106,7 @@ Sirchmunk 采用 **无索引** 方法：
 任何 OpenAI 兼容 API 端点，包括但不限于：
 - OpenAI（GPT-5.2, ...）
 - [MiniMax](https://platform.minimax.io)（MiniMax-M3、MiniMax-M2.7、MiniMax-M2.7-highspeed）
+- [OrcaRouter](https://www.orcarouter.ai)（openai/gpt-4o、openai/gpt-4o-mini、deepseek/deepseek-v4-flash、...）
 - DeepSeek、Moonshot、Mistral、Groq、Together AI、Cohere
 - Google Gemini、智谱（GLM）、百川、零一万物、硅基流动、火山引擎
 - Azure OpenAI
@@ -1102,6 +1122,15 @@ LLM_MODEL_NAME=MiniMax-M3
 ```
 
 详见 [MiniMax OpenAI 兼容 API 文档](https://platform.minimax.io/docs/api-reference/text-openai-api)。
+
+使用 OrcaRouter 的配置示例：
+```bash
+LLM_BASE_URL=https://api.orcarouter.ai/v1
+LLM_API_KEY=your-orcarouter-api-key
+LLM_MODEL_NAME=openai/gpt-4o
+```
+
+OrcaRouter 一个 API key 即可访问 200+ 模型（OpenAI、Anthropic、Google、DeepSeek 等）；模型 id 使用路由器自身的 `provider/model` 格式（如 `openai/gpt-4o`、`deepseek/deepseek-v4-flash`）。
 
 </details>
 

--- a/src/sirchmunk/llm/openai_chat.py
+++ b/src/sirchmunk/llm/openai_chat.py
@@ -74,6 +74,7 @@ _PROVIDERS: Dict[str, _ProviderProfile] = {
     "groq":        _ProviderProfile("groq"),
     "cohere":      _ProviderProfile("cohere"),
     "minimax":     _ProviderProfile("minimax"),
+    "orcarouter":  _ProviderProfile("orcarouter"),
 }
 
 # URL substring → provider name.  More specific patterns must precede less
@@ -96,6 +97,7 @@ _URL_PATTERNS = [
     ("cohere",            "cohere"),
     ("baichuan-ai.com",   "baichuan"),
     ("minimax",           "minimax"),
+    ("orcarouter.ai",     "orcarouter"),
 ]
 
 _DEFAULT_PROFILE = _ProviderProfile("generic")


### PR DESCRIPTION
## What

Registers **OrcaRouter** as a named provider in Sirchmunk's capability
negotiation, alongside the existing named providers (DeepSeek, MiniMax,
SiliconFlow, etc.).

OrcaRouter ([https://www.orcarouter.ai](https://www.orcarouter.ai)) is an
OpenAI-compatible router exposing 200+ models (OpenAI, Anthropic, Google,
DeepSeek, ...) behind a single API key. Model ids use the router's own
`provider/model` format (e.g. `openai/gpt-4o`). It already worked through
the generic OpenAI-compatible path (`LLM_BASE_URL`), and this change makes
it first-class:

- **`src/sirchmunk/llm/openai_chat.py`**: added `"orcarouter"` to the
  `_PROVIDERS` capability profiles and `("orcarouter.ai", "orcarouter")` to
  `_URL_PATTERNS`, so a base URL of `https://api.orcarouter.ai/v1` is
  auto-detected and negotiated with the generic-safe profile
  (`stream_options` enabled, no thinking parameter).
- **README.md / README_zh.md**: listed OrcaRouter in the supported
  providers, added an env config example (`LLM_BASE_URL`, `LLM_API_KEY`,
  `LLM_MODEL_NAME`), and a "Using with OrcaRouter" Python SDK example.

## Why

OrcaRouter users previously had to type the endpoint manually into the
generic OpenAI-compatible path. A named profile presets the endpoint,
correctly negotiates streaming options, and surfaces OrcaRouter in the
documented provider list — the same treatment the other named providers get.

## How to Test

1. Live API (real OrcaRouter key): `OpenAIChat(api_key="sk-orca-...",
   base_url="https://api.orcarouter.ai/v1", model="openai/gpt-4o").chat(...)`
   returns "hello from orcarouter" (non-streaming and streaming, with usage).
2. Auto-detection: `OpenAIChat._detect_provider("https://api.orcarouter.ai/v1")`
   returns the `orcarouter` profile.
3. `uvx --from ruff@0.8.4 ruff check src/sirchmunk/llm/openai_chat.py` — clean.

## Related Issue

None.

## Checklist

- [x] `py_compile` clean; provider registration + detection verified
- [x] Live test with a real OrcaRouter key (non-stream + stream via
      `OpenAIChat`, both return usage)
- [x] `ruff` (repo-pinned v0.8.4) clean on the changed file
- [ ] `black` — note: the changed file is not black-formatted at `main`
      (pre-existing, whole file), so the diff matches the file's existing
      alignment style rather than reformatting the file.

> Disclosure: I'm an engineer on the OrcaRouter team.
