### PR TITLE
fix(storage): preserve WAL on checkpoint failure

### DIFF
--- a/src/sirchmunk/storage/duckdb.py
+++ b/src/sirchmunk/storage/duckdb.py
@@ -119,19 +119,17 @@ class DuckDBManager:
         logger.info(
             f"Stale WAL detected at {wal_file}, checkpointing before load"
         )
+        tmp_conn = None
         try:
             tmp_conn = duckdb.connect(db_file)
             tmp_conn.execute("CHECKPOINT")
-            tmp_conn.close()
             logger.info(f"WAL checkpoint completed for {db_file}")
         except Exception as e:
-            logger.warning(f"WAL checkpoint failed for {db_file}: {e}")
-            # Last resort: remove the stale WAL so READ_ONLY ATTACH can proceed
-            try:
-                wal_file.unlink()
-                logger.info(f"Removed stale WAL file {wal_file}")
-            except Exception:
-                pass
+            logger.error(f"WAL checkpoint failed for {db_file}: {e}")
+            raise
+        finally:
+            if tmp_conn is not None:
+                tmp_conn.close()
 
     @staticmethod
     def _cleanup_wal(db_file: str):


### PR DESCRIPTION
## Summary

- Preserve the DuckDB WAL file when checkpoint recovery fails instead of deleting it.
- Propagate checkpoint errors to prevent startup from continuing after an unsuccessful recovery.
- Ensure the temporary DuckDB connection is closed on both success and failure.

Deleting the WAL after a failed checkpoint can permanently discard committed transactions that have not yet been merged into the main database file.

## Test plan

- [x] Verified `src/sirchmunk/storage/duckdb.py` compiles with `python3 -m py_compile`.
- [x] Verified checkpoint errors are propagated instead of being swallowed.
- [x] Verified the WAL file and its contents are preserved when checkpoint recovery fails.
- [x] Verified the temporary DuckDB connection is closed after a checkpoint failure.
- [x] Passed trailing-whitespace and end-of-file checks.
- [x] Passed the added-large-file check.
- [x] Passed Ruff checks.
- [x] Confirmed the repository currently has no pytest tests to collect.

